### PR TITLE
Show solution on loss and center on-screen keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
       transition: transform .07s ease, background .2s;
     }
     .tile.reveal { transform: scale(1.02); }
-    .kbs { display:grid; gap:8px; padding:8px; }
+    .kbs { display:flex; flex-direction:column; gap:8px; padding:8px; align-items:center; margin:0 auto; }
     .kb-row { display:flex; gap:6px; justify-content:center; }
     .key {
       background:#2c3140; color:var(--text); border:none; padding:12px 10px;
@@ -69,13 +69,14 @@
   <div class="app">
     <header>
       <h1>WORDLE</h1>
-      <div style="display:flex; gap:8px;">
-        <button class="icon" id="btn-new">New</button>
-        <button class="icon" id="btn-share">Share</button>
-        <button class="icon" id="btn-free">Free Play</button>
-        <button class="icon" id="btn-install" style="display:none;">Install</button>
-      </div>
-    </header>
+        <div style="display:flex; gap:8px;">
+          <button class="icon" id="btn-new">New</button>
+          <button class="icon" id="btn-share">Share</button>
+          <button class="icon" id="btn-free">Free Play</button>
+          <button class="icon" id="btn-update">Update</button>
+          <button class="icon" id="btn-install" style="display:none;">Install</button>
+        </div>
+      </header>
 
     <div class="status" id="status"></div>
 
@@ -112,6 +113,15 @@
     </div>
   </div>
 
+  <div class="modal hidden" id="lose-modal">
+    <div class="modal-box">
+      <h2>Game Over</h2>
+      <p>The word was <span id="lose-word"></span>.</p>
+      <button id="lose-share">Share</button>
+      <button id="lose-close">Close</button>
+    </div>
+  </div>
+
   <div class="modal hidden" id="free-modal">
     <div class="modal-box">
       <h2>Free Play</h2>
@@ -123,8 +133,9 @@
 
   <script>
     // --- PWA install prompt handling ---
-    let deferredPrompt = null;
-    window.addEventListener('beforeinstallprompt', (e) => {
+      let deferredPrompt = null;
+      let swReg;
+      window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       deferredPrompt = e;
       document.getElementById('btn-install').style.display = 'inline-block';
@@ -137,10 +148,14 @@
       document.getElementById('btn-install').style.display = 'none';
     });
 
-    // --- Service Worker ---
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));
-    }
+      // --- Service Worker ---
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('./sw.js').then(reg => {
+            swReg = reg;
+          });
+        });
+      }
 
     // --- Game State ---
     const ANSWERS = [
@@ -384,7 +399,12 @@
         incrementStats(true, row);
         if (!freePlay) $('win-modal').classList.remove('hidden');
       }
-      else { toastMsg("The word was '"+target+"'"); incrementStats(false, ROWS); }
+      else {
+        toastMsg("Out of tries! The word was '"+target+"'");
+        incrementStats(false, ROWS);
+        $('lose-word').textContent = target;
+        $('lose-modal').classList.remove('hidden');
+      }
       updateStatsUI();
     }
 
@@ -448,6 +468,21 @@
     $('intro-start').addEventListener('click', () => $('intro-modal').classList.add('hidden'));
     $('win-close').addEventListener('click', () => $('win-modal').classList.add('hidden'));
     $('win-share').addEventListener('click', doShare);
+    $('lose-close').addEventListener('click', () => $('lose-modal').classList.add('hidden'));
+    $('lose-share').addEventListener('click', doShare);
+
+    $('btn-update').addEventListener('click', async () => {
+      if (!swReg) return;
+      await swReg.update();
+      if (swReg.waiting) {
+        if (confirm('Update available. Reload now?')) {
+          swReg.waiting.postMessage({type:'SKIP_WAITING'});
+        }
+      } else {
+        toastMsg('Already up to date');
+      }
+    });
+    navigator.serviceWorker.addEventListener('controllerchange', () => location.reload());
 
     function newGame() {
       target = freePlay ? pickRandomWord() : pickWord(); row=0; col=0; over=false;

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 
 // Basic service worker for offline caching
-const CACHE = 'wordlish-v1';
+const CACHE = 'wordlish-v2';
 const ASSETS = [
   './',
   './index.html',
@@ -10,7 +10,7 @@ const ASSETS = [
 ];
 
 self.addEventListener('install', (e) => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(()=> self.skipWaiting()));
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
 
 self.addEventListener('activate', (e) => {
@@ -21,6 +21,9 @@ self.addEventListener('activate', (e) => {
   })());
 });
 
+self.addEventListener('message', (e) => {
+  if (e.data?.type === 'SKIP_WAITING') self.skipWaiting();
+});
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
   // Network-first for html, cache-first for others


### PR DESCRIPTION
## Summary
- Reveal correct word in a "Game Over" modal and allow sharing directly from the popup
- Center the on-screen keyboard beneath the board with a flex layout and auto margin
- Add an Update button to trigger a service-worker refresh and purge old caches
- Clarify the toast message shown on losses

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fa2f296a08331abd1ae0345c7265a