### PR TITLE
feat: add update button and service worker update flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,6 +73,7 @@
         <button class="icon" id="btn-new">New</button>
         <button class="icon" id="btn-share">Share</button>
         <button class="icon" id="btn-free">Free Play</button>
+        <button class="icon" id="btn-update">Update</button>
         <button class="icon" id="btn-install" style="display:none;">Install</button>
       </div>
     </header>
@@ -133,6 +134,7 @@
   <script>
     // --- PWA install prompt handling ---
     let deferredPrompt = null;
+    let swReg;
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       deferredPrompt = e;
@@ -148,8 +150,23 @@
 
     // --- Service Worker ---
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));
+      navigator.serviceWorker.register('./sw.js').then(reg => {
+        swReg = reg;
+      });
+      navigator.serviceWorker.addEventListener('controllerchange', () => location.reload());
     }
+
+    document.getElementById('btn-update').addEventListener('click', async () => {
+      if (!swReg) return;
+      await swReg.update();
+      if (swReg.waiting) {
+        if (confirm('Update available. Reload now?')) {
+          swReg.waiting.postMessage({type:'SKIP_WAITING'});
+        }
+      } else {
+        toastMsg('Already up to date');
+      }
+    });
 
     // --- Game State ---
     const ANSWERS = [

--- a/sw.js
+++ b/sw.js
@@ -1,6 +1,6 @@
 
 // Basic service worker for offline caching
-const CACHE = 'wordlish-v1';
+const CACHE = 'wordlish-v2';
 const ASSETS = [
   './',
   './index.html',
@@ -9,8 +9,12 @@ const ASSETS = [
   './icon-512.png'
 ];
 
+self.addEventListener('message', e => {
+  if (e.data?.type === 'SKIP_WAITING') self.skipWaiting();
+});
+
 self.addEventListener('install', (e) => {
-  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)).then(()=> self.skipWaiting()));
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(ASSETS)));
 });
 
 self.addEventListener('activate', (e) => {


### PR DESCRIPTION
## Summary
- add Update button to header
- wire service worker update flow with user confirmation and cache version bump

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689fb0c2a3408331be455cb9a8f22d8a